### PR TITLE
Add `createToken` function to new `window.Stripe.card` object

### DIFF
--- a/lib/fake_stripe/assets/v1.js
+++ b/lib/fake_stripe/assets/v1.js
@@ -32,3 +32,7 @@ window.Stripe = {
   validateCVC: function(value) { return true; },
   validateExpiry: function(value) { return true; }
 };
+
+window.Stripe.card = {
+  createToken: window.Stripe.createToken
+};


### PR DESCRIPTION
Fixes #14.

In the real Stripe javascript, `createToken` is defined both on
`Stripe` and on `Stripe.card`, and the documentation says to use
`Stripe.card.createToken`.
