### PR TITLE
Require JSON dependency

### DIFF
--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'sinatra/base'
 
 module FakeStripe

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 require 'fake_stripe'
 require 'pry'
+require 'rack/test'
 require 'rspec'
 require 'stripe'
-require 'rack/test'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|


### PR DESCRIPTION
- Fixes errors during specs from missing JSON

```
FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF.....

Failures:

  1) Stub app POST plans returns valid json
     Failure/Error: expect { JSON.parse(last_response.body) }.not_to raise_error
       expected no Exception, got #<NameError: uninitialized constant JSON> with backtrace:
         # ./spec/fake_stripe/requests/stub_app_spec.rb:129:in `block (5 levels) in <top (required)>'
         # ./spec/fake_stripe/requests/stub_app_spec.rb:129:in `block (4 levels) in <top (required)>'
     # ./spec/fake_stripe/requests/stub_app_spec.rb:129:in `block (4 levels) in <top (required)>'

```
