### PR TITLE
Track customer creation count and expose it

### DIFF
--- a/lib/fake_stripe.rb
+++ b/lib/fake_stripe.rb
@@ -24,8 +24,17 @@ module FakeStripe
     @@refund_count = refund_count
   end
 
+  def self.customer_count
+    @@customer_count
+  end
+
+  def self.customer_count=(customer_count)
+    @@customer_count = customer_count
+  end
+
   def self.reset
     @@charge_count = 0
+    @@customer_count = 0
     @@refund_count = 0
   end
 

--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -32,6 +32,7 @@ module FakeStripe
 
     # Customers
     post '/v1/customers' do
+      FakeStripe.customer_count += 1
       json_response 200, fixture('create_customer')
     end
 

--- a/spec/fake_stripe/stub_app_spec.rb
+++ b/spec/fake_stripe/stub_app_spec.rb
@@ -28,4 +28,12 @@ describe FakeStripe::StubApp do
       end.to change(FakeStripe, :refund_count).by(1)
     end
   end
+
+  describe "POST /v1/customers" do
+    it "increments the customer counter" do
+      expect do
+        Stripe::Customer.create
+      end.to change(FakeStripe, :customer_count).by(1)
+    end
+  end
 end


### PR DESCRIPTION
Not all Stripe interactions create charges. It's handy to know if your
code created a customer.
