### PR TITLE
Update POST /accounts response to include a bank account

### DIFF
--- a/lib/fake_stripe/fixtures/create_account.json
+++ b/lib/fake_stripe/fixtures/create_account.json
@@ -25,21 +25,23 @@
   "debit_negative_balances": true,
   "bank_accounts": {
     "object": "list",
-    "total_count": 0,
-    "has_more": false,
-    "url": "/v1/accounts/acct_1032D82eZvKYlo2C/bank_accounts",
-    "data": [
-
-    ]
-  },
-  "external_accounts": {
-    "object": "list",
-    "total_count": 0,
+    "total_count": 1,
     "has_more": false,
     "url": "/v1/accounts/acct_1032D82eZvKYlo2C/external_accounts",
-    "data": [
-
-    ]
+    "data": [{
+      "id":"ba_16ndClBdETbGCbQrGski5zps",
+      "object":"bank_account",
+      "last4":"1234",
+      "country":"US",
+      "currency":"usd",
+      "status":"new",
+      "fingerprint":"axCsvGRahxD6fvu0",
+      "routing_number":"110000000",
+      "bank_name":"STRIPE TEST BANK",
+      "account":"acct_28ndDlB5ETbGCaQr",
+      "default_for_currency":true,
+      "metadata":{}
+    }]
   },
   "verification": {
     "fields_needed": [

--- a/lib/fake_stripe/version.rb
+++ b/lib/fake_stripe/version.rb
@@ -1,3 +1,3 @@
 module FakeStripe
-  VERSION = '0.0.10'
+  VERSION = '0.0.10.1'
 end


### PR DESCRIPTION
- Assume a new Stripe account has a bank account
- Update `POST /accounts` endpoint to include bank account data in the
  `external_accounts` property
