### PR TITLE
Support retrieving an account by ID

### DIFF
--- a/lib/fake_stripe/fixtures/retrieve_account.json
+++ b/lib/fake_stripe/fixtures/retrieve_account.json
@@ -15,5 +15,25 @@
   ],
   "default_currency": "usd",
   "country": "US",
-  "object": "account"
+  "object": "account",
+  "bank_accounts": {
+    "object": "list",
+    "total_count": 1,
+    "has_more": false,
+    "url": "/v1/accounts/acct_1032D82eZvKYlo2C/external_accounts",
+    "data": [{
+      "id":"ba_16ndClBdETbGCbQrGski5zps",
+      "object":"bank_account",
+      "last4":"1234",
+      "country":"US",
+      "currency":"usd",
+      "status":"new",
+      "fingerprint":"axCsvGRahxD6fvu0",
+      "routing_number":"110000000",
+      "bank_name":"STRIPE TEST BANK",
+      "account":"acct_28ndDlB5ETbGCaQr",
+      "default_for_currency":true,
+      "metadata":{}
+    }]
+  }
 }

--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -268,6 +268,10 @@ module FakeStripe
       json_response 200, fixture('retrieve_account')
     end
 
+    get '/v1/accounts/:account_id' do
+      json_response 200, fixture('retrieve_account')
+    end
+
     post "/v1/accounts" do
       json_response 201, fixture("create_account")
     end

--- a/spec/fake_stripe/stub_app_spec.rb
+++ b/spec/fake_stripe/stub_app_spec.rb
@@ -1,6 +1,22 @@
 require 'spec_helper'
 
 describe FakeStripe::StubApp do
+  describe "GET /v1/accounts/:account_id" do
+    it "returns an account response" do
+      result = Stripe::Account.retrieve("stripe-account-id")
+
+      expect(result.object).to eq("account")
+    end
+  end
+
+  describe "GET /v1/account" do
+    it "returns an account response" do
+      result = Stripe::Account.retrieve
+
+      expect(result.object).to eq("account")
+    end
+  end
+
   describe "POST /v1/accounts" do
     it "returns an account response" do
       result = Stripe::Account.create


### PR DESCRIPTION
- Add `GET /v1/accounts/:account_id` endpoint
- Add test for `GET /v1/account` endpoint
- Stripe API reference for retrieving accounts: https://stripe.com/docs/api/curl#retrieve_account
