### PR TITLE
Add external_accounts key to account responses

### DIFF
--- a/lib/fake_stripe/fixtures/create_account.json
+++ b/lib/fake_stripe/fixtures/create_account.json
@@ -23,29 +23,31 @@
   "managed": false,
   "product_description": null,
   "debit_negative_balances": true,
-  "bank_accounts": {
+  "external_accounts": {
     "object": "list",
-    "total_count": 1,
+    "data": [
+      {
+        "id":"ba_16ndClBdETbGCbQrGski5zps",
+        "object": "bank_account",
+        "account":"acct_28ndDlB5ETbGCaQr",
+        "bank_name": "STRIPE TEST BANK",
+        "country": "US",
+        "currency": "usd",
+        "default_for_currency": true,
+        "fingerprint":"axCsvGRahxD6fvu0",
+        "last4": "1234",
+        "metadata": {},
+        "routing_number": "110000000",
+        "status": "new"
+      }
+    ],
     "has_more": false,
-    "url": "/v1/accounts/acct_1032D82eZvKYlo2C/external_accounts",
-    "data": [{
-      "id":"ba_16ndClBdETbGCbQrGski5zps",
-      "object":"bank_account",
-      "last4":"1234",
-      "country":"US",
-      "currency":"usd",
-      "status":"new",
-      "fingerprint":"axCsvGRahxD6fvu0",
-      "routing_number":"110000000",
-      "bank_name":"STRIPE TEST BANK",
-      "account":"acct_28ndDlB5ETbGCaQr",
-      "default_for_currency":true,
-      "metadata":{}
-    }]
+    "total_count": 1,
+    "url": "/v1/accounts/acct_1032D82eZvKYlo2C/external_accounts"
   },
   "verification": {
     "fields_needed": [
-      "bank_account",
+      "external_account",
       "business_url",
       "product_description",
       "support_phone",

--- a/lib/fake_stripe/fixtures/update_account.json
+++ b/lib/fake_stripe/fixtures/update_account.json
@@ -23,29 +23,31 @@
   "managed": false,
   "product_description": null,
   "debit_negative_balances": true,
-  "bank_accounts": {
+  "external_accounts": {
     "object": "list",
-    "total_count": 1,
+    "data": [
+      {
+        "id":"ba_16ndClBdETbGCbQrGski5zps",
+        "object": "bank_account",
+        "account":"acct_39ndDlB5ETbGCsWt",
+        "bank_name": "STRIPE TEST BANK",
+        "country": "US",
+        "currency": "usd",
+        "default_for_currency": true,
+        "fingerprint":"axCsvGRahxD6fvu0",
+        "last4": "1234",
+        "metadata": {},
+        "routing_number": "110000000",
+        "status": "new"
+      }
+    ],
     "has_more": false,
-    "url": "/v1/accounts/acct_1032D82eZvKYlo2C/external_accounts",
-    "data": [{
-      "id":"ba_16ndClBdETbGCbQrGski5xad",
-      "object":"bank_account",
-      "last4":"2345",
-      "country":"US",
-      "currency":"usd",
-      "status":"new",
-      "fingerprint":"axCsvGRahxD6fvu0",
-      "routing_number":"110000000",
-      "bank_name":"STRIPE TEST BANK",
-      "account":"acct_39ndDlB5ETbGCsWt",
-      "default_for_currency":true,
-      "metadata":{}
-    }]
+    "total_count": 1,
+    "url": "/v1/accounts/acct_1032D82eZvKYlo2C/external_accounts"
   },
   "verification": {
     "fields_needed": [
-      "bank_account",
+      "external_account",
       "business_url",
       "product_description",
       "support_phone",


### PR DESCRIPTION
Why:
- Stripe's [documentation](https://stripe.com/docs/api#update_account)
  only mentions `external_accounts`.
  Perhaps this new attribute is meant to reaplace `bank_accounts`?
- However, Stripe still returns `bank_accounts` as well as
  `external_accounts`.
- Add `external_accounts` here and keep `bank_accounts` too.
