### PR TITLE
Update the create charge response/fixture

### DIFF
--- a/lib/fake_stripe/fixtures/create_charge.json
+++ b/lib/fake_stripe/fixtures/create_charge.json
@@ -1,45 +1,65 @@
 {
-  "id": "ch_1HLqBx9AyixBof",
+  "id": "ch_17hjFm2eZvKYlo2Cf6ceKOqV",
   "object": "charge",
-  "created": 1360691193,
-  "livemode": false,
-  "paid": true,
   "amount": 1000,
+  "amount_refunded": 0,
+  "application_fee": null,
+  "balance_transaction": "txn_17bBUd2eZvKYlo2CAv3mOn7F",
+  "captured": true,
+  "created": 1456245794,
   "currency": "usd",
+  "customer": "cus_7xeYRmuGuwvZK1",
+  "description": "Charge for VirtuMedix consultation for Guy Henggeler",
+  "destination": null,
+  "dispute": null,
+  "failure_code": null,
+  "failure_message": null,
+  "fraud_details": {
+  },
+  "invoice": null,
+  "livemode": false,
+  "metadata": {
+  },
+  "order": null,
+  "paid": true,
+  "receipt_email": null,
+  "receipt_number": null,
   "refunded": false,
-  "fee": 59,
-  "fee_details": [
-    {
-      "amount": 59,
-      "currency": "usd",
-      "type": "stripe_fee",
-      "description": "Stripe processing fees",
-      "application": null
-    }
-  ],
-  "card": {
+  "refunds": {
+    "object": "list",
+    "data": [
+
+    ],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/charges/ch_17hjFm2eZvKYlo2Cf6ceKOqV/refunds"
+  },
+  "shipping": null,
+  "source": {
+    "id": "card_17hjFk2eZvKYlo2CuvsYuAE1",
     "object": "card",
-    "last4": "4242",
-    "brand": "Visa",
-    "exp_month": 11,
-    "exp_year": 2014,
-    "fingerprint": "qhjxpr7DiCdFYTlH",
-    "country": "US",
-    "name": "john doe",
-    "address_line1": null,
-    "address_line2": null,
     "address_city": null,
+    "address_country": null,
+    "address_line1": null,
+    "address_line1_check": null,
+    "address_line2": null,
     "address_state": null,
     "address_zip": null,
-    "address_country": null,
+    "address_zip_check": null,
+    "brand": "Visa",
+    "country": "US",
+    "customer": "cus_7xeYRmuGuwvZK1",
     "cvc_check": "pass",
-    "address_line1_check": null,
-    "address_zip_check": null
+    "dynamic_last4": null,
+    "exp_month": 2,
+    "exp_year": 2017,
+    "funding": "credit",
+    "last4": "4242",
+    "metadata": {
+    },
+    "name": null,
+    "tokenization_method": null
   },
-  "failure_message": null,
-  "amount_refunded": 0,
-  "customer": null,
-  "invoice": null,
-  "description": "Polygonian licensing",
-  "dispute": null
+  "statement_descriptor": null,
+  "status": "succeeded"
 }


### PR DESCRIPTION
#### What does this PR do?
- Updates the create charge fixture to represent the current response from the Stripe API
- The `card` object in the response is causing tests to break. In the Stripe API response the object is named `source` instead of `card` which is the error that is causing the breaking tests.
  *Updated the entire fixture to represent what is currently returned from the Stripe API
#### What is the relevant documentation?

[Stripe Create Charge API Response](https://stripe.com/docs/api/curl#create_charge)
#### Where should I start?

`lib/fake_stripe/fixtures/create_charge.json`
#### How this PR makes you feel?

![high_five](https://cloud.githubusercontent.com/assets/529465/13260619/7e2f3600-da19-11e5-89c0-a71748a0ecce.gif)

Also could someone email me once this merged so I can change the Gemfile in the project this is affecting?
