### PR TITLE
Add sources to create_customer.json fixture

### DIFF
--- a/lib/fake_stripe/fixtures/create_customer.json
+++ b/lib/fake_stripe/fixtures/create_customer.json
@@ -8,6 +8,38 @@
   "delinquent": false,
   "metadata": {
   },
+  "sources": {
+    "object": "list",
+    "data": [
+      {
+        "id": "card_1234567890ABCDEFghijklmn",
+        "object": "card",
+        "address_city": null,
+        "address_country": null,
+        "address_line1": null,
+        "address_line1_check": null,
+        "address_line2": null,
+        "address_state": null,
+        "address_zip": null,
+        "address_zip_check": null,
+        "brand": "Visa",
+        "country": "US",
+        "customer": "abcdefghijklmnop",
+        "cvc_check": "pass",
+        "dynamic_last4": null,
+        "exp_month": 10,
+        "exp_year": 2016,
+        "funding": "credit",
+        "last4": "4242",
+        "metadata": {},
+        "name": null,
+        "tokenization_method": null
+      }
+    ],
+    "has_more": false,
+    "total_count": 1,
+    "url": "/v1/customers/abcdefghijklmnop/subscriptions"
+  },
   "subscriptions": {
     "object": "list",
     "count": 0,


### PR DESCRIPTION
`sources` is a part of the Stripe api's customer object. Some unrelated
gems use the `Stripe::Customer#sources` method, like [the payola gem].

This commit adds the `sources` key/object literal to the
create_customer.json fixture to better match the [result returned by the Stripe API].

[the payola gem]: https://github.com/peterkeen/payola/blob/master/app/services/payola/start_subscription.rb#L46
[result returned by the Stripe API]: https://stripe.com/docs/api#customer_object