### PR TITLE
Explicitly enable WebMock in initializer

### DIFF
--- a/lib/fake_stripe/initializers/webmock.rb
+++ b/lib/fake_stripe/initializers/webmock.rb
@@ -1,3 +1,4 @@
 require 'webmock'
 include WebMock::API
+WebMock.enable!
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
Fixes #43

When WebMock is not enabled in the spec_helper of the application being tested,
requests to the Stripe API are not intercepted by WebMock.

According to the WebMock documentation, in order to use WebMock outside a test
framework, `WebMock.enable!` needs to be called. Adding this to the WebMock
initializer makes WebMock actually work, and also fixes the build. I'm not sure
why the build started failing; there must have been a change to Stripe's API.