### PR TITLE
Use a different last4 after updating an account

### DIFF
--- a/lib/fake_stripe/fixtures/update_account.json
+++ b/lib/fake_stripe/fixtures/update_account.json
@@ -35,7 +35,7 @@
         "currency": "usd",
         "default_for_currency": true,
         "fingerprint":"axCsvGRahxD6fvu0",
-        "last4": "1234",
+        "last4": "2345",
         "metadata": {},
         "routing_number": "110000000",
         "status": "new"


### PR DESCRIPTION
In ae403f40d307ef86f19e6a1b2d0d4ec0facc9ce5, the `last4` of an updated account was changed from `2345` to `1234`. Since `1234` is also the `last4` of a created account, there's now no way to assert on the `last4` of an account changing.

This changes the `last4` of an updated account to be different from the `last4` of a newly created account.