### PR TITLE
Use the correct `url` key for sources

### DIFF
--- a/lib/fake_stripe/fixtures/create_customer.json
+++ b/lib/fake_stripe/fixtures/create_customer.json
@@ -38,7 +38,7 @@
     ],
     "has_more": false,
     "total_count": 1,
-    "url": "/v1/customers/abcdefghijklmnop/subscriptions"
+    "url": "/v1/customers/abcdefghijklmnop/sources"
   },
   "subscriptions": {
     "object": "list",


### PR DESCRIPTION
In 4d52ba67bdf41b01724e0320db0c747e0e5bf552, the `sources` key was added to `create_customer.json`. Instead of using `/sources` as the `sources.url` key, it used `/subscriptions`. This makes tests that try to retrieve sources retrieve subscriptions instead, e.g.:

    customer.sources.retrieve(customer.default_source)

According to Stripe's https://stripe.com/docs/api#customer_object documentation, this is the correct URL.