### PR TITLE
Successfully retrieve a source

### DIFF
--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -74,6 +74,10 @@ module FakeStripe
       json_response 200, fixture('list_cards')
     end
 
+    get '/v1/customers/:customer_id/sources/:id' do
+      json_response 200, fixture('retrieve_card')
+    end
+
     # Subscriptions
     post '/v1/customers/:customer_id/subscriptions' do
       FakeStripe.subscription_count += 1


### PR DESCRIPTION
Assume that the `source` (which could be a credit card or a bank account) is in
fact a card, since the `create_customer.json` lists the source as a card.

Without this, Stripe 404s when it tries to retreive an customer's source.

(Apologies for not fully testing this before in #47. I pointed my app at the
local fake_stripe this time and all tests run green.)