### PR TITLE
gitignore pkg/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ log/*.log
 *.swp
 bin/
 Gemfile.lock
+pkg/


### PR DESCRIPTION
`rake release` creates a `pkg/` directory to store the built gem.