### PR TITLE
Swap 'default_card' with 'default_source'

### DIFF
--- a/lib/fake_stripe/fixtures/create_customer.json
+++ b/lib/fake_stripe/fixtures/create_customer.json
@@ -79,5 +79,5 @@
       }
     ]
   },
-  "default_card": "card_1234567890ABCDEFghijklmn"
+  "default_source": "card_1234567890ABCDEFghijklmn"
 }

--- a/lib/fake_stripe/fixtures/list_customers.json
+++ b/lib/fake_stripe/fixtures/list_customers.json
@@ -51,7 +51,7 @@
         }
       ]
     },
-    "default_card": "card_1234567890ABCDEFghijklmn"
+    "default_source": "card_1234567890ABCDEFghijklmn"
   },
   {
     "object": "customer",
@@ -101,7 +101,7 @@
         }
       ]
     },
-    "default_card": "card_103ewU2eZvKYlo2CVToIWv6R"
+    "default_source": "card_103ewU2eZvKYlo2CVToIWv6R"
   },
   {
     "object": "customer",
@@ -151,7 +151,7 @@
         }
       ]
     },
-    "default_card": "card_103ewU2eZvKYlo2CVToIWv6S"
+    "default_source": "card_103ewU2eZvKYlo2CVToIWv6S"
   }
   ]
 }

--- a/lib/fake_stripe/fixtures/retrieve_customer.json
+++ b/lib/fake_stripe/fixtures/retrieve_customer.json
@@ -47,5 +47,5 @@
       }
     ]
   },
-  "default_card": "card_1234567890ABCDEFghijklmn"
+  "default_source": "card_1234567890ABCDEFghijklmn"
 }

--- a/lib/fake_stripe/fixtures/update_customer.json
+++ b/lib/fake_stripe/fixtures/update_customer.json
@@ -47,5 +47,5 @@
       }
     ]
   },
-  "default_card": "card_1234567890ABCDEFghijklmn"
+  "default_source": "card_1234567890ABCDEFghijklmn"
 }


### PR DESCRIPTION
Why:

* The Stripe API uses 'default_source'

This change addresses the need by:

* Replace all occurrences of 'default_card' with 'default_source'
* These changes are limited to the fixtures directory

Reference Links:

* https://stripe.com/docs/api#customer_object