### PR TITLE
Plan hash in subscription

### DIFF
--- a/lib/fake_stripe/fixtures/cancel_subscription.json
+++ b/lib/fake_stripe/fixtures/cancel_subscription.json
@@ -1,6 +1,19 @@
 {
   "id": "sub_3ewdhCIki3FxWt",
-  "plan": "basic",
+  "plan": {
+    "interval": "month",
+    "name": "New plan name123",
+    "created": 1386247539,
+    "amount": 2000,
+    "currency": "usd",
+    "id": "gold21323",
+    "object": "plan",
+    "livemode": false,
+    "interval_count": 1,
+    "trial_period_days": null,
+    "metadata": {
+    }
+  },
   "object": "subscription",
   "start": 1394732152,
   "status": "active",

--- a/lib/fake_stripe/fixtures/create_subscription.json
+++ b/lib/fake_stripe/fixtures/create_subscription.json
@@ -1,6 +1,19 @@
 {
   "id": "sub_3ewdhCIki3FxWt",
-  "plan": "basic",
+  "plan": {
+    "interval": "month",
+    "name": "New plan name123",
+    "created": 1386247539,
+    "amount": 2000,
+    "currency": "usd",
+    "id": "gold21323",
+    "object": "plan",
+    "livemode": false,
+    "interval_count": 1,
+    "trial_period_days": null,
+    "metadata": {
+    }
+  },
   "object": "subscription",
   "start": 1394732152,
   "status": "active",

--- a/lib/fake_stripe/fixtures/update_subscription.json
+++ b/lib/fake_stripe/fixtures/update_subscription.json
@@ -1,6 +1,19 @@
 {
   "id": "sub_3ewdhCIki3FxWt",
-  "plan": "basic",
+  "plan": {
+    "interval": "month",
+    "name": "New plan name123",
+    "created": 1386247539,
+    "amount": 2000,
+    "currency": "usd",
+    "id": "gold21323",
+    "object": "plan",
+    "livemode": false,
+    "interval_count": 1,
+    "trial_period_days": null,
+    "metadata": {
+    }
+  },
   "object": "subscription",
   "start": 1394732152,
   "status": "active",

--- a/spec/fake_stripe/requests/subscriptions_spec.rb
+++ b/spec/fake_stripe/requests/subscriptions_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'Subscription request' do
+  include Rack::Test::Methods
+
+  SUBSCRIPTIONS_TESTS = {
+    # Subscriptions
+    'POST customers/:customer_id/subscriptions' =>
+       { route: '/v1/customers/1/subscriptions', method: :post },
+    'GET customers/:customer_id/subscriptions/:subscription_id' =>
+       { route: '/v1/customers/1/subscriptions/1', method: :get },
+    'POST customers/:customer_id/subscriptions/:subscription_id' =>
+       { route: '/v1/customers/1/subscriptions/1', method: :post },
+    'DELETE customers/:customer_id/subscriptions/:subscription_id' =>
+       { route: '/v1/customers/1/subscriptions/1', method: :delete }
+  }
+
+  SUBSCRIPTIONS_TESTS.each_pair do |name, action|
+    describe name do
+      it 'includes plan hash in response' do
+        send action[:method], action[:route]
+
+        expect(JSON.parse(last_response.body)["plan"]["interval"]).to eq "month"
+      end
+    end
+  end
+
+  describe 'GET customers/:customer_id/subscriptions' do
+    it 'includes plan hash in response' do
+      get '/v1/customers/1/subscriptions'
+
+      expect(JSON.parse(last_response.body)["data"][0]["plan"]["interval"]).to eq "month"
+    end
+  end
+
+  def app
+    FakeStripe::StubApp.new
+  end
+end


### PR DESCRIPTION
First, thanks for sharing this gem!

I tried to use this gem in my app when I noticed that in some part of subscription related fixtures, the plan value is not returned as a hash as per api docs: https://stripe.com/docs/api/curl#subscription_object

Hopefully this can be useful for somebody else too