### PR TITLE
Add instructions for Stripe.js v2 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,20 @@ unless defined? STRIPE_JS_HOST
 end
 ```
 
-Include the Stripe JavaScript in your application template:
+Include the Stripe JavaScript in your application template.
+
+If you're using Stripe.js v1:
 
 ```rhtml
 # app/views/layouts/application.html.erb
 <%= javascript_include_tag "#{STRIPE_JS_HOST}/v1/" %>
+```
+
+Or if you're using Stripe.js v2:
+
+```rhtml
+# app/views/layouts/application.html.erb
+<%= javascript_include_tag "#{STRIPE_JS_HOST}/v2/" %>
 ```
 
 When the test suite runs `fake_stripe` will override the address for


### PR DESCRIPTION
Stripe.js v2 is the default when you go to their docs: https://stripe.com/docs/stripe.js

So we should provide instructions for both :)

This library already supports v2 (#21).

I'd also be fine with a shorter version, probably v2 as the default and with a note about changing to v1 if you're using that.