### PR TITLE
Stub newer subscriptions API endpoint

### DIFF
--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -75,25 +75,50 @@ module FakeStripe
     end
 
     # Subscriptions
-    post '/v1/customers/:customer_id/subscriptions' do
-      FakeStripe.subscription_count += 1
-      json_response 200, fixture('create_subscription')
+    [
+      '/v1/subscriptions',
+      '/v1/customers/:customer_id/subscriptions',
+    ].each do |path|
+      post path do
+        FakeStripe.subscription_count += 1
+        json_response 200, fixture('create_subscription')
+      end
     end
 
-    get '/v1/customers/:customer_id/subscriptions/:subscription_id' do
-      json_response 200, fixture('retrieve_subscription')
+    [
+      '/v1/subscriptions/:subscription_id',
+      '/v1/customers/:customer_id/subscriptions/:subscription_id',
+    ].each do |path|
+      get path do
+        json_response 200, fixture('retrieve_subscription')
+      end
     end
 
-    post '/v1/customers/:customer_id/subscriptions/:subscription_id' do
-      json_response 200, fixture('update_subscription')
+    [
+      '/v1/subscriptions/:subscription_id',
+      '/v1/customers/:customer_id/subscriptions/:subscription_id',
+    ].each do |path|
+      post path do
+        json_response 200, fixture('update_subscription')
+      end
     end
 
-    delete '/v1/customers/:customer_id/subscriptions/:subscription_id' do
-      json_response 200, fixture('cancel_subscription')
+    [
+      '/v1/subscriptions/:subscription_id',
+      '/v1/customers/:customer_id/subscriptions/:subscription_id',
+    ].each do |path|
+      delete path do
+        json_response 200, fixture('cancel_subscription')
+      end
     end
 
-    get '/v1/customers/:customer_id/subscriptions' do
-      json_response 200, fixture('list_subscriptions')
+    [
+      '/v1/subscriptions',
+      '/v1/customers/:customer_id/subscriptions',
+    ].each do |path|
+      get path do
+        json_response 200, fixture('list_subscriptions')
+      end
     end
 
     # Plans

--- a/spec/fake_stripe/requests/stub_app_spec.rb
+++ b/spec/fake_stripe/requests/stub_app_spec.rb
@@ -33,6 +33,17 @@ describe 'Stub app' do
     'GET customers/:customer_id/sources' =>
        { route: '/v1/customers/1/sources', method: :get },
     # Subscriptions
+    'POST subscriptions' =>
+       { route: '/v1/subscriptions', method: :post },
+    'GET subscriptions/:subscription_id' =>
+       { route: '/v1/subscriptions/1', method: :get },
+    'POST subscriptions/:subscription_id' =>
+       { route: '/v1/subscriptions/1', method: :post },
+    'DELETE subscriptions/:subscription_id' =>
+       { route: '/v1/subscriptions/1', method: :delete },
+    'GET subscriptions' =>
+       { route: '/v1/subscriptions', method: :get },
+    # Subscriptions
     'POST customers/:customer_id/subscriptions' =>
        { route: '/v1/customers/1/subscriptions', method: :post },
     'GET customers/:customer_id/subscriptions/:subscription_id' =>


### PR DESCRIPTION
The `stripe-ruby` library uses Stripe's newer subscription API by
default after version 1.42.0 (released 2016-05-04).

Relevant PR here: https://github.com/stripe/stripe-ruby/pull/411
