### PR TITLE
Update `count` Field to `total_count` in All Fixtures

### DIFF
--- a/lib/fake_stripe/fixtures/cancel_transfer.json
+++ b/lib/fake_stripe/fixtures/cancel_transfer.json
@@ -49,7 +49,7 @@
   },
   "transactions": {
     "object": "list",
-    "count": 626,
+    "total_count": 626,
     "url": "/v1/transfers/tr_103ehW2eZvKYlo2CvqXdcIQL/transactions",
     "data": [
       {

--- a/lib/fake_stripe/fixtures/create_customer.json
+++ b/lib/fake_stripe/fixtures/create_customer.json
@@ -42,7 +42,7 @@
   },
   "subscriptions": {
     "object": "list",
-    "count": 0,
+    "total_count": 0,
     "url": "/v1/customers/abcdefghijklmnop/subscriptions",
     "data": [
 

--- a/lib/fake_stripe/fixtures/create_invoice.json
+++ b/lib/fake_stripe/fixtures/create_invoice.json
@@ -24,7 +24,7 @@
         }
       }
     ],
-    "count": 1,
+    "total_count": 1,
     "object": "list",
     "url": "/v1/invoices/in_103ewP2eZvKYlo2CFLLwIX7a/lines"
   },

--- a/lib/fake_stripe/fixtures/create_transfer.json
+++ b/lib/fake_stripe/fixtures/create_transfer.json
@@ -49,7 +49,7 @@
   },
   "transactions": {
     "object": "list",
-    "count": 626,
+    "total_count": 626,
     "url": "/v1/transfers/tr_103ehW2eZvKYlo2CvqXdcIQL/transactions",
     "data": [
       {

--- a/lib/fake_stripe/fixtures/list_application_fees.json
+++ b/lib/fake_stripe/fixtures/list_application_fees.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "/v1/application_fees",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "id": "fee_3ewdpQuL9AggWF",

--- a/lib/fake_stripe/fixtures/list_balance_history.json
+++ b/lib/fake_stripe/fixtures/list_balance_history.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "/v1/balance/history",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "id": "txn_103cQg2eZvKYlo2CYKVlR2nh",

--- a/lib/fake_stripe/fixtures/list_cards.json
+++ b/lib/fake_stripe/fixtures/list_cards.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "/v1/customers/cu_103ewU2eZvKYlo2CUREXSezP/cards",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "id": "card_103ewd2eZvKYlo2CzCsKfISF",

--- a/lib/fake_stripe/fixtures/list_charges.json
+++ b/lib/fake_stripe/fixtures/list_charges.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
     "url": "/v1/charges",
-    "count": 3,
+    "total_count": 3,
     "data": [
       {
       "id": "ch_103ewb2eZvKYlo2CjopvmZyM",

--- a/lib/fake_stripe/fixtures/list_coupons.json
+++ b/lib/fake_stripe/fixtures/list_coupons.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "/v1/coupons",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "id": "25OFF",

--- a/lib/fake_stripe/fixtures/list_customers.json
+++ b/lib/fake_stripe/fixtures/list_customers.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "v1/customers",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "object": "customer",
@@ -15,7 +15,7 @@
     },
     "subscriptions": {
       "object": "list",
-      "count": 0,
+      "total_count": 0,
       "url": "/v1/customers/abcdefghijklmnop/subscriptions",
       "data": [
       ]
@@ -25,7 +25,7 @@
     "currency": "usd",
     "sources": {
       "object": "list",
-      "count": 1,
+      "total_count": 1,
       "url": "/v1/customers/abcdefghijklmnop/sources",
       "data": [
         {
@@ -66,7 +66,7 @@
     },
     "subscriptions": {
       "object": "list",
-      "count": 0,
+      "total_count": 0,
       "url": "/v1/customers/cus_3ewUPsNuSVb5hF/subscriptions",
       "data": [
       ]
@@ -76,7 +76,7 @@
     "currency": "usd",
     "sources": {
       "object": "list",
-      "count": 1,
+      "total_count": 1,
       "url": "/v1/customers/cus_3ewUPsNuSVb5hF/sources",
       "data": [
         {
@@ -117,7 +117,7 @@
     },
     "subscriptions": {
       "object": "list",
-      "count": 0,
+      "total_count": 0,
       "url": "/v1/customers/cus_3ewUPsNuSVb5hG/subscriptions",
       "data": [
       ]
@@ -127,7 +127,7 @@
     "currency": "usd",
     "sources": {
       "object": "list",
-      "count": 1,
+      "total_count": 1,
       "url": "/v1/customers/cus_3ewUPsNuSVb5hG/sources",
       "data": [
         {

--- a/lib/fake_stripe/fixtures/list_events.json
+++ b/lib/fake_stripe/fixtures/list_events.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "/v1/events",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "id": "evt_103ewb2eZvKYlo2Cz0MZagvE",

--- a/lib/fake_stripe/fixtures/list_invoiceitems.json
+++ b/lib/fake_stripe/fixtures/list_invoiceitems.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "/v1/invoiceitems",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "object": "invoiceitem",

--- a/lib/fake_stripe/fixtures/list_invoices.json
+++ b/lib/fake_stripe/fixtures/list_invoices.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "/v1/invoices",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "date": 1394731307,
@@ -41,7 +41,7 @@
           "metadata": null
         }
       ],
-      "count": 1,
+      "total_count": 1,
       "object": "list",
       "url": "/v1/invoices/in_103ewP2eZvKYlo2CFLLwIX7a/lines"
     },
@@ -105,7 +105,7 @@
           "metadata": null
         }
       ],
-      "count": 1,
+      "total_count": 1,
       "object": "list",
       "url": "/v1/invoices/in_103ewP2eZvKYlo2CFLLwIX7b/lines"
     },
@@ -169,7 +169,7 @@
           "metadata": null
         }
       ],
-      "count": 1,
+      "total_count": 1,
       "object": "list",
       "url": "/v1/invoices/in_103ewP2eZvKYlo2CFLLwIX7c/lines"
     },

--- a/lib/fake_stripe/fixtures/list_plans.json
+++ b/lib/fake_stripe/fixtures/list_plans.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "/v1/plans",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "interval": "month",

--- a/lib/fake_stripe/fixtures/list_recipients.json
+++ b/lib/fake_stripe/fixtures/list_recipients.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "v1/recipients",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "id": "rp_103WyK2eZvKYlo2CXgqlepdQ",

--- a/lib/fake_stripe/fixtures/list_subscriptions.json
+++ b/lib/fake_stripe/fixtures/list_subscriptions.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "/v1/customers/cu_103ewU2eZvKYlo2CUREXSezP/subscriptions",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "id": "sub_3ewdhCIki3FxWt",

--- a/lib/fake_stripe/fixtures/list_transfers.json
+++ b/lib/fake_stripe/fixtures/list_transfers.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "/v1/transfers",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "id": "tr_103ehW2eZvKYlo2CvqXdcIQL",
@@ -54,7 +54,7 @@
     },
     "transactions": {
       "object": "list",
-      "count": 626,
+      "total_count": 626,
       "url": "/v1/transfers/tr_103ehW2eZvKYlo2CvqXdcIQL/transactions",
       "data": [
         {
@@ -214,7 +214,7 @@
     },
     "transactions": {
       "object": "list",
-      "count": 626,
+      "total_count": 626,
       "url": "/v1/transfers/tr_103ehW2eZvKYlo2CvqXdcIQM/transactions",
       "data": [
         {
@@ -374,7 +374,7 @@
     },
     "transactions": {
       "object": "list",
-      "count": 626,
+      "total_count": 626,
       "url": "/v1/transfers/tr_103ehW2eZvKYlo2CvqXdcIQN/transactions",
       "data": [
         {

--- a/lib/fake_stripe/fixtures/pay_invoice.json
+++ b/lib/fake_stripe/fixtures/pay_invoice.json
@@ -36,7 +36,7 @@
         "metadata": null
       }
     ],
-    "count": 1,
+    "total_count": 1,
     "object": "list",
     "url": "/v1/invoices/in_103ewP2eZvKYlo2CFLLwIX7a/lines"
   },

--- a/lib/fake_stripe/fixtures/retrieve_customer.json
+++ b/lib/fake_stripe/fixtures/retrieve_customer.json
@@ -42,7 +42,7 @@
   },
   "subscriptions": {
     "object": "list",
-    "count": 0,
+    "total_count": 0,
     "url": "/v1/customers/abcdefghijklmnop/subscriptions",
     "data": [
 

--- a/lib/fake_stripe/fixtures/retrieve_invoice.json
+++ b/lib/fake_stripe/fixtures/retrieve_invoice.json
@@ -36,7 +36,7 @@
         "metadata": null
       }
     ],
-    "count": 1,
+    "total_count": 1,
     "object": "list",
     "url": "/v1/invoices/in_103ewP2eZvKYlo2CFLLwIX7a/lines"
   },

--- a/lib/fake_stripe/fixtures/retrieve_invoice_line_items.json
+++ b/lib/fake_stripe/fixtures/retrieve_invoice_line_items.json
@@ -1,7 +1,7 @@
 {
   "object": "list",
   "url": "/v1/invoices/in_103ewP2eZvKYlo2CFLLwIX7a/lines",
-  "count": 3,
+  "total_count": 3,
   "data": [
     {
     "id": "ii_103UAn2eZvKYlo2CkLmj7ne9",

--- a/lib/fake_stripe/fixtures/retrieve_upcoming_invoice.json
+++ b/lib/fake_stripe/fixtures/retrieve_upcoming_invoice.json
@@ -4,7 +4,7 @@
   "period_end": 1394731307,
   "lines": {
     "object": "list",
-    "count": 1,
+    "total_count": 1,
     "url": "/v1/invoices/upcoming/lines?customer=abcdefghijklmnop",
     "data": [
       {

--- a/lib/fake_stripe/fixtures/update_customer.json
+++ b/lib/fake_stripe/fixtures/update_customer.json
@@ -42,7 +42,7 @@
   },
   "subscriptions": {
     "object": "list",
-    "count": 0,
+    "total_count": 0,
     "url": "/v1/customers/abcdefghijklmnop/subscriptions",
     "data": [
 

--- a/lib/fake_stripe/fixtures/update_invoice.json
+++ b/lib/fake_stripe/fixtures/update_invoice.json
@@ -36,7 +36,7 @@
         "metadata": null
       }
     ],
-    "count": 1,
+    "total_count": 1,
     "object": "list",
     "url": "/v1/invoices/in_103ewP2eZvKYlo2CFLLwIX7a/lines"
   },

--- a/lib/fake_stripe/fixtures/update_transfer.json
+++ b/lib/fake_stripe/fixtures/update_transfer.json
@@ -49,7 +49,7 @@
   },
   "transactions": {
     "object": "list",
-    "count": 626,
+    "total_count": 626,
     "url": "/v1/transfers/tr_103ehW2eZvKYlo2CvqXdcIQL/transactions",
     "data": [
       {


### PR DESCRIPTION
The API changed as of version 2014-03-28, eliminating the `count` field on all objects and replacing it with the `total_count` field. The fixtures contained the old name, so this changes all the fixtures to reflect the new field name.

See https://stripe.com/docs/upgrades#2014-03-28.
