### PR TITLE
Add new path 'POST /v1/refunds'

### DIFF
--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -17,6 +17,11 @@ module FakeStripe
       json_response 200, fixture('update_charge')
     end
 
+    post '/v1/refunds' do
+      FakeStripe.refund_count += 1
+      json_response 200, fixture('refund_charge')
+    end
+
     post '/v1/charges/:charge_id/refund' do
       FakeStripe.refund_count += 1
       json_response 200, fixture('refund_charge')

--- a/spec/fake_stripe/requests/stub_app_spec.rb
+++ b/spec/fake_stripe/requests/stub_app_spec.rb
@@ -8,6 +8,7 @@ describe 'Stub app' do
     'POST charges' => { route: '/v1/charges', method: :post },
     'GET charges/:charge_id' => { route: '/v1/charges/1', method: :get },
     'POST charges/:charge_id' => { route: '/v1/charges/1', method: :post },
+    'POST refunds' => { route: '/v1/refunds', method: :post },
     'POST charges/:charge_id/refund' =>
     { route: '/v1/charges/1/refund', method: :post },
     'POST charges/:charge_id/capture' =>

--- a/spec/fake_stripe/stub_app_spec.rb
+++ b/spec/fake_stripe/stub_app_spec.rb
@@ -50,6 +50,20 @@ describe FakeStripe::StubApp do
     end
   end
 
+  describe 'POST /v1/refunds' do
+    it 'returns a fake refund response' do
+      result = Stripe::Refund.create(charge: 'ABC123')
+
+      expect(result.refunded).to eq true
+    end
+
+    it 'increments the refund counter' do
+      expect do
+        Stripe::Refund.create(charge: 'ABC123')
+      end.to change(FakeStripe, :refund_count).by(1)
+    end
+  end
+
   describe 'POST /v1/charges/:charge_id/refund' do
     it 'returns a fake refund response' do
       result = Stripe::Charge.retrieve('ABC123').refund


### PR DESCRIPTION
Add new route and API for refunds. Keep old path for backwards
compatibility.

The new path can be seen here: https://stripe.com/docs/api/curl#create_refund

The new API for creating refunds was added in this commit:
https://github.com/stripe/stripe-ruby/commit/13979ce5be5829b3a872c257be31ef8afbb3b89f