### PR TITLE
Revert "Use the real stripe URL"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,15 @@ you can add `gem 'sinatra', '2.0.0.beta2'` to the `:test` group in your Gemfile.
 
 ### Stripe settings
 
+Set the `STRIPE_JS_HOST` constant in an initializer:
+
 ```ruby
 # config/initializers/stripe.rb
 Stripe.api_key = ENV['STRIPE_API_KEY']
+
+unless defined? STRIPE_JS_HOST
+  STRIPE_JS_HOST = 'https://js.stripe.com'
+end
 ```
 
 Include the Stripe JavaScript in your application template.
@@ -41,18 +47,18 @@ If you're using Stripe.js v1:
 
 ```rhtml
 # app/views/layouts/application.html.erb
-<%= javascript_include_tag "https://js.stripe.com/v1/" %>
+<%= javascript_include_tag "#{STRIPE_JS_HOST}/v1/" %>
 ```
 
 Or if you're using Stripe.js v2:
 
 ```rhtml
 # app/views/layouts/application.html.erb
-<%= javascript_include_tag "https://js.stripe.com/v2/" %>
+<%= javascript_include_tag "#{STRIPE_JS_HOST}/v2/" %>
 ```
 
-When the test suite runs `fake_stripe` will intercept requests to the Stripe
-address and serve up a local version of [Stripe.js](https://stripe.com/docs/stripe.js).
+When the test suite runs `fake_stripe` will override the address for
+`STRIPE_JS_HOST` and serve up a local version of [Stripe.js](https://stripe.com/docs/stripe.js).
 
 ### In Tests
 

--- a/lib/fake_stripe.rb
+++ b/lib/fake_stripe.rb
@@ -33,8 +33,8 @@ module FakeStripe
     Stripe.api_key = 'FAKE_STRIPE_API_KEY'
     FakeStripe.reset
     stub_request(:any, /api.stripe.com/).to_rack(FakeStripe::StubApp)
-    stub_request(:any, /js.stripe.com/).to_rack(FakeStripe::StubApp)
   end
 end
 
-FakeStripe::StubStripeJS.boot
+server = FakeStripe::StubStripeJS.boot
+STRIPE_JS_HOST = "http://#{server.host}:#{server.port}"


### PR DESCRIPTION
Closes [#60].

This reverts commit 9f2e58a131dbb7f28a1d289c31297580ac04365e.

[#60]: https://github.com/thoughtbot/fake_stripe/issues/60