### PR TITLE
Add card to account external_accounts

### DIFF
--- a/lib/fake_stripe/fixtures/retrieve_account.json
+++ b/lib/fake_stripe/fixtures/retrieve_account.json
@@ -55,10 +55,35 @@
         "metadata": {},
         "routing_number": "110000000",
         "status": "new"
+      },
+      {
+        "id": "card_1A7TO92eZvKYlo2C3bb6h8pO",
+        "object": "card",
+        "address_city": null,
+        "address_country": null,
+        "address_line1": null,
+        "address_line1_check": null,
+        "address_line2": null,
+        "address_state": null,
+        "address_zip": null,
+        "address_zip_check": null,
+        "brand": "Visa",
+        "country": "US",
+        "customer": "cus_ASOAEvtZXhPszU",
+        "cvc_check": "unchecked",
+        "dynamic_last4": null,
+        "exp_month": 10,
+        "exp_year": 2020,
+        "funding": "debit",
+        "last4": "4242",
+        "metadata": {
+        },
+        "name": null,
+        "tokenization_method": null
       }
     ],
     "has_more": false,
-    "total_count": 1,
+    "total_count": 2,
     "url": "/v1/accounts/acct_16vteKH0GjZwV0ke/external_accounts"
   },
   "legal_entity": {


### PR DESCRIPTION
Adds a card to the `external_accounts` for a given Stripe account.