### PR TITLE
Faster require

### DIFF
--- a/lib/fake_stripe.rb
+++ b/lib/fake_stripe.rb
@@ -32,9 +32,9 @@ module FakeStripe
   def self.stub_stripe
     Stripe.api_key = 'FAKE_STRIPE_API_KEY'
     FakeStripe.reset
+    FakeStripe::StubStripeJS.boot_once
     stub_request(:any, /api.stripe.com/).to_rack(FakeStripe::StubApp)
   end
 end
 
-server = FakeStripe::StubStripeJS.boot
-STRIPE_JS_HOST = "http://#{server.host}:#{server.port}"
+STRIPE_JS_HOST = "http://localhost:#{FakeStripe::StubStripeJS.server_port}"

--- a/lib/fake_stripe/stub_stripe_js.rb
+++ b/lib/fake_stripe/stub_stripe_js.rb
@@ -1,5 +1,6 @@
 require 'capybara'
 require 'capybara/server'
+require 'fake_stripe/utils'
 require 'sinatra/base'
 
 module FakeStripe
@@ -21,9 +22,17 @@ module FakeStripe
       IO.read(file_path) + IO.read(mock_file_path)
     end
 
-    def self.boot
+    def self.boot(port = FakeStripe::Utils.find_available_port)
       instance = new
-      Capybara::Server.new(instance).tap { |server| server.boot }
+      Capybara::Server.new(instance, port).tap { |server| server.boot }
+    end
+
+    def self.boot_once
+      @@stripe_js_server ||= FakeStripe::StubStripeJS.boot(self.server_port)
+    end
+
+    def self.server_port
+      @@stripe_js_port ||= FakeStripe::Utils.find_available_port
     end
   end
 end

--- a/lib/fake_stripe/utils.rb
+++ b/lib/fake_stripe/utils.rb
@@ -1,0 +1,14 @@
+require 'socket'
+
+module FakeStripe
+  class Utils
+    FIND_AVAILABLE_PORT = 0
+
+    def self.find_available_port
+      server = TCPServer.new(FIND_AVAILABLE_PORT)
+      server.addr[1]
+    ensure
+      server.close if server
+    end
+  end
+end

--- a/spec/fake_stripe/requests/stripe_js_spec.rb
+++ b/spec/fake_stripe/requests/stripe_js_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'net/http'
+
+describe 'Stub Stripe JS' do
+  it 'returns the requested asset' do
+    url = URI.parse(STRIPE_JS_HOST)
+    url.path = '/v1/'
+
+    response = Net::HTTP.get(url)
+
+    expect(response).to include 'window.Stripe'
+  end
+end

--- a/spec/fake_stripe/stub_stripe_js_spec.rb
+++ b/spec/fake_stripe/stub_stripe_js_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe FakeStripe::StubStripeJS do
+  describe '#boot_once' do
+    it 'returns the same server each invocation' do
+      expect(described_class.boot_once).to eq described_class.boot_once
+    end
+  end
+
+  describe '#server_port' do
+    it 'returns the same value each invocation' do
+      expect(described_class.server_port).to eq described_class.server_port
+    end
+  end
+end

--- a/spec/fake_stripe/utils_spec.rb
+++ b/spec/fake_stripe/utils_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe FakeStripe::Utils do
+  describe '#find_available_port' do
+    it 'returns a port value' do
+      expect(described_class.find_available_port).to be_a Numeric
+    end
+  end
+end


### PR DESCRIPTION
Requiring `fake_stripe` is slow because it [boots the Stripe JS server immediately](https://github.com/thoughtbot/fake_stripe/blob/f0996529891713863f115ec8ce99fd0ade4db94d/lib/fake_stripe.rb#L39), even when `FakeStripe.stub_stripe` hasn't been called yet.

This PR proposes:

- Only boot Fake Stripe JS server when needed.
- Still perform the identification of an available port early, so `STRIPE_JS_HOST` can be populated correctly.

## Impact

By deferring spinning up a Capybara server until necessary there's a significant improvement on the time to require the gem.

Running command:

```
repeat 10 { /usr/bin/time -p bundle exec ruby -e "require 'fake_stripe'" 2>&1 } | grep real
```

|          | Before (secs) | After (secs) |
|----------|---------------|--------------|
|          | 5.85          | 0.71         |
|          | 5.74          | 0.71         |
|          | 5.75          | 0.72         |
|          | 5.81          | 0.69         |
|          | 5.81          | 0.7          |
|          | 5.72          | 0.68         |
|          | 5.72          | 0.67         |
|          | 5.81          | 0.71         |
|          | 5.79          | 0.7          |
|          | 5.81          | 0.66         |
| **Average:** | **5.781**         | **0.695**        |

## Motivation

When I run an non-Stripe related test I don't want to experience the performance penalty. Today one would have to use the following in a Gemfile & explicitly require `fake_stripe` later:

```
gem "fake_stripe", require: false
```

After this PR there's far less performance impact of a vanilla require `fake_stripe` in the Gemfile like:

```
gem "fake_stripe"
```