### PR TITLE
Bank Account routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ log/*.log
 bin/
 Gemfile.lock
 pkg/
+.idea

--- a/lib/fake_stripe/fixtures/delete_bank_account.json
+++ b/lib/fake_stripe/fixtures/delete_bank_account.json
@@ -1,0 +1,4 @@
+{
+  "deleted": true,
+  "id": "ba_103ewd2eZvKYlo2CzCsKfISF"
+}

--- a/lib/fake_stripe/fixtures/retrieve_bank_account.json
+++ b/lib/fake_stripe/fixtures/retrieve_bank_account.json
@@ -1,0 +1,18 @@
+{
+  "id": "ba_AdDnqVodgyllM7",
+  "object": "bank_account",
+  "account": "acct_23JZqd8aZx3igsin7Zny",
+  "account_holder_name": "Jane Austen",
+  "account_holder_type": "individual",
+  "bank_name": "STRIPE TEST BANK",
+  "country": "US",
+  "currency": "usd",
+  "default_for_currency": false,
+  "fingerprint": "PnB8FUaXClXjGyOU",
+  "last4": "6789",
+  "metadata": {
+  },
+  "routing_number": "110000000",
+  "status": "new",
+  "customer": "cus_AcounLdkoJSxvJ"
+}

--- a/lib/fake_stripe/fixtures/update_bank_account.json
+++ b/lib/fake_stripe/fixtures/update_bank_account.json
@@ -1,0 +1,18 @@
+{
+  "id": "ba_AdDnqVodgyllM7",
+  "object": "bank_account",
+  "account": "acct_23JZqd8aZx3igsin7Zny",
+  "account_holder_name": "Jane Austen",
+  "account_holder_type": "individual",
+  "bank_name": "STRIPE TEST BANK 2",
+  "country": "US",
+  "currency": "usd",
+  "default_for_currency": false,
+  "fingerprint": "PnB8FUaXClXjGyOU",
+  "last4": "6789",
+  "metadata": {
+  },
+  "routing_number": "110000000",
+  "status": "new",
+  "customer": "cus_AcounLdkoJSxvJ"
+}

--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -57,6 +57,19 @@ module FakeStripe
       json_response 200, fixture('list_customers')
     end
 
+    # Bank Accounts
+    get %r(/v1/customers/.+/sources/ba_.+) do
+      json_response 200, fixture('retrieve_bank_account')
+    end
+
+    post %r(/v1/customers/.+/sources/ba_.+) do
+      json_response 200, fixture('update_bank_account')
+    end
+
+    delete %r(/v1/customers/.+/sources/ba_.+) do
+      json_response 200, fixture('delete_bank_account')
+    end
+    
     # Cards
     post '/v1/customers/:customer_id/sources' do
       FakeStripe.card_count += 1

--- a/spec/fake_stripe/requests/stub_app_spec.rb
+++ b/spec/fake_stripe/requests/stub_app_spec.rb
@@ -22,6 +22,13 @@ describe 'Stub app' do
     'DELETE customers/:customer_id' =>
        { route: '/v1/customers/1', method: :delete },
     'GET customers' => { route: '/v1/customers', method: :get },
+    # Bank Accounts
+    'GET customers/:customer_id/sources/:bank_account_id' =>
+        { route: '/v1/customers/1/sources/ba_1', method: :get },
+    'POST customers/:customer_id/sources/:bank_account_id' =>
+        { route: '/v1/customers/1/sources/ba_1', method: :post },
+    'DELETE customers/:customer_id/sources/:bank_account_id' =>
+        { route: '/v1/customers/1/sources/ba_1', method: :delete },
     # Cards
     'POST customers/:customer_id/sources' =>
        { route: '/v1/customers/1/sources', method: :post },


### PR DESCRIPTION
added stubs for  `get`, `post` and `delete` requests to `/v1/customers/:customer_id/sources/:bank_account_id` route

parameter `:bank_account_id` only matches strings that starts with `ba_`, so it shouldn't broke compatibility with `/v1/customers/:customer_id/sources/:card_id` routes