### PR TITLE
Remove Rails 5 Compatibility instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,6 @@ end
 
 Remember to run `bundle install`.
 
-### Rails 5 Compatibility
-
-`fake_stripe` depends on Sinatra, which is currently in the process of being
-upgraded to use Rack 2.0, a requirement for compatibility with Rails 5. This
-should be resolved once Sinatra 2.0 is officially released; in the meantime,
-you can add `gem 'sinatra', '2.0.0.beta2'` to the `:test` group in your Gemfile.
-
 ### Stripe settings
 
 Set the `STRIPE_JS_HOST` constant in an initializer:


### PR DESCRIPTION
With the release of Sinatra 2.0, this section of the README is no longer required.
#44 is no longer an issue.