### PR TITLE
Add 3D secure object to js

### DIFF
--- a/lib/fake_stripe/assets/v2.js
+++ b/lib/fake_stripe/assets/v2.js
@@ -275,6 +275,21 @@
 
   }).call(this, this.Stripe.token);
 
+  this.Stripe.threeDSecure = (function() {
+    function threeDSecure() {}
+
+    threeDSecure.create = function(params, callback) {
+      if ("object" != typeof b)
+        throw new Error("params must be an object.");
+      if ("function" != typeof c)
+        throw new Error("callback must be a function.");
+
+      callback(200, {status: 'succeeded'});
+    }
+
+    return threeDSecure;
+  }).call();
+
   this.Stripe.bitcoinReceiver = (function() {
 
     function bitcoinReceiver() {}


### PR DESCRIPTION
Currently if a `Stripe.threeDSecure.create` call is made it gets an undefined error, this adds an implementation that simply calls the callback function with a success response.