### PR TITLE
Correct incorrect test command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 1. Fork the repo.
 
 2. Run the tests. We only take pull requests with passing tests, and it's great
-to know that you have a clean slate: `bundle && rspec spec`
+to know that you have a clean slate: `bundle && rspec`
 
 3. Create your feature branch (`git checkout -b my-new-feature`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 1. Fork the repo.
 
 2. Run the tests. We only take pull requests with passing tests, and it's great
-to know that you have a clean slate: `bundle && rake`
+to know that you have a clean slate: `bundle && rspec spec`
 
 3. Create your feature branch (`git checkout -b my-new-feature`).
 


### PR DESCRIPTION
I forked this repo to make a PR to update some of the fixtures to include `outcome` and `fraud_details`. Upon following these instructions, I discovered there is no default rake task and therefore does not work. I'm not sure if the preference is to create a rake task to run the specs like Rails does but this command correctly runs the test suite.