### PR TITLE
Add support for Stripe::EphemeralKey

### DIFF
--- a/lib/fake_stripe/fixtures/create_ephemeral_key.json
+++ b/lib/fake_stripe/fixtures/create_ephemeral_key.json
@@ -1,0 +1,11 @@
+ {
+  "id": "ephkey_abcdefghijklmop",
+  "object": "ephemeral_key",
+  "associated_objects": [
+    {"id":"cus_abcdefghijklmnop","type":"customer"}
+  ],
+  "created": 1509726002,
+  "expires": 1509729602,
+  "livemode": false,
+  "secret": "ek_test_abcdefghijklmnop"
+}

--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -354,6 +354,11 @@ module FakeStripe
       json_response 200, fixture('retrieve_token')
     end
 
+    # Ephemeral Keys
+    post '/v1/ephemeral_keys' do
+      json_response 201, fixture('create_ephemeral_key')
+    end
+
     private
 
     def fixture(file_name)

--- a/spec/fake_stripe/requests/stub_app_spec.rb
+++ b/spec/fake_stripe/requests/stub_app_spec.rb
@@ -127,7 +127,8 @@ describe 'Stub app' do
     'GET events' => { route: '/v1/events', method: :get },
     # Tokens
     'POST tokens' => { route: '/v1/tokens', method: :post },
-    'GET tokens/:token_id' => { route: '/v1/tokens/1', method: :get }
+    'GET tokens/:token_id' => { route: '/v1/tokens/1', method: :get },
+    'POST ephemeral_keys' => { route: '/v1/ephemeral_keys', method: :post }
   }
 
   TESTS.each_pair do |name, action|

--- a/spec/fake_stripe/stub_app_spec.rb
+++ b/spec/fake_stripe/stub_app_spec.rb
@@ -183,4 +183,12 @@ describe FakeStripe::StubApp do
       end
     end
   end
+
+  describe "POST /v1/ephemeral_keys" do
+    it "returns an ephemeral_key response" do
+      result = Stripe::EphemeralKey.create({customer: '123'}, stripe_version: '123')
+
+      expect(result.object).to eq("ephemeral_key")
+    end
+  end
 end


### PR DESCRIPTION
Add support for `Stripe::EphemeralKey` which is used when working with mobile clients. See [stripe docs](https://stripe.com/docs/mobile/ios/standard) for more details on how this is used.