### PR TITLE
Follow Capybara deprecation warning

### DIFF
--- a/lib/fake_stripe/stub_stripe_js.rb
+++ b/lib/fake_stripe/stub_stripe_js.rb
@@ -24,7 +24,7 @@ module FakeStripe
 
     def self.boot(port = FakeStripe::Utils.find_available_port)
       instance = new
-      Capybara::Server.new(instance, port).tap { |server| server.boot }
+      Capybara::Server.new(instance, port: port).tap { |server| server.boot }
     end
 
     def self.boot_once


### PR DESCRIPTION
"Positional arguments, other than the application, to Server#new are deprecated, please use keyword arguments"

https://github.com/teamcapybara/capybara/blob/master/lib/capybara/server.rb#L21