### PR TITLE
Return error on native or zero amounts

### DIFF
--- a/fake_stripe.gemspec
+++ b/fake_stripe.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sinatra'
   s.add_dependency 'webmock'
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'puma'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'stripe'
 end

--- a/lib/fake_stripe/fixtures/invalid_positive_integer.json
+++ b/lib/fake_stripe/fixtures/invalid_positive_integer.json
@@ -1,0 +1,8 @@
+{
+  "error" :
+  {
+      "type"    : "invalid_request_error",
+      "message" : "Invalid positive integer",
+      "param"   : "amount"
+  }
+}

--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -5,8 +5,12 @@ module FakeStripe
 
     # Charges
     post '/v1/charges' do
-      FakeStripe.charge_count += 1
-      json_response 201, fixture('create_charge')
+      if params['amount'] && params['amount'].to_i <= 0
+        json_response 400, fixture('invalid_positive_integer')
+      else
+        FakeStripe.charge_count += 1
+        json_response 201, fixture('create_charge')
+      end
     end
 
     get '/v1/charges/:charge_id' do

--- a/spec/fake_stripe/stub_app_spec.rb
+++ b/spec/fake_stripe/stub_app_spec.rb
@@ -48,6 +48,23 @@ describe FakeStripe::StubApp do
         Stripe::Charge.create
       end.to change(FakeStripe, :charge_count).by(1)
     end
+
+    context 'with an invalid amount' do
+      it 'returns an error' do
+        expect do
+          Stripe::Charge.create(amount: -100)
+        end.to raise_error(Stripe::InvalidRequestError)
+      end
+
+      it 'does not increment the charge counter' do
+        expect do
+          begin
+            Stripe::Charge.create(amount: 0)
+          rescue Stripe::InvalidRequestError
+          end
+        end.not_to change(FakeStripe, :charge_count)
+      end
+    end
   end
 
   describe 'POST /v1/refunds' do


### PR DESCRIPTION
When you pass a negative or 0 as an amount to Stripe it results in an
error being returned. On our app that uses FakeStripe, we had a bug
that was sending negative amounts to be charged and this was not caught
by the specs because FakeStripe was happily taking this request.

This introduces this error state to match the behavior of the Stripe
API. If a zero or negative amount is attemoted to be charged, an error
will be returned.

This is related to #19, but only validates this one parameter.