### PR TITLE
Fix - getting element from string

### DIFF
--- a/lib/fake_stripe/assets/v3.js
+++ b/lib/fake_stripe/assets/v3.js
@@ -1,7 +1,7 @@
 class Element {
   mount(el) {
     if (typeof el === "string") {
-      el = document.querySelector(el)[0];
+      el = document.querySelector(el);
     }
 
     el.innerHTML = `


### PR DESCRIPTION
- According to https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector method querySelector() returns the first Element within the document