### PR TITLE
Fix - Remove Webmock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,14 +4,13 @@ PATH
     fake_stripe (0.2.0)
       capybara
       sinatra
-      webmock
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    capybara (3.10.0)
+    capybara (3.18.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -20,30 +19,27 @@ GEM
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
     coderay (1.1.2)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
-    hashdiff (0.3.7)
     method_source (0.9.0)
     mini_mime (1.0.1)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     multipart-post (2.0.0)
     mustermann (1.0.3)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.3)
+      mini_portile2 (~> 2.4.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
     puma (3.12.0)
-    rack (2.0.5)
-    rack-protection (2.0.4)
+    rack (2.0.7)
+    rack-protection (2.0.5)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    regexp_parser (1.2.0)
+    regexp_parser (1.4.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -59,19 +55,14 @@ GEM
     rspec-support (3.8.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    safe_yaml (1.0.4)
-    sinatra (2.0.4)
+    sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.4)
+      rack-protection (= 2.0.5)
       tilt (~> 2.0)
     stripe (3.28.0)
       faraday (~> 0.10)
-    tilt (2.0.8)
-    webmock (3.4.2)
-      addressable (>= 2.3.6)
-      crack (>= 0.3.2)
-      hashdiff
+    tilt (2.0.9)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -87,4 +78,4 @@ DEPENDENCIES
   stripe
 
 BUNDLED WITH
-   1.16.5
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 This library is a way to test [Stripe](http://www.stripe.com/) code without hitting Stripe's
 servers. It uses
-[Capybara::Server](https://github.com/jnicklas/capybara/blob/master/lib/capybara/server.rb)
-and [Webmock](https://github.com/bblimke/webmock) to intercept all of the calls from Stripe's
+[Capybara::Server](https://github.com/jnicklas/capybara/blob/master/lib/capybara/server.rb) to intercept all of the calls from Stripe's
 Ruby library and returns JSON that the Stripe library can parse.
 
 ## Installation

--- a/fake_stripe.gemspec
+++ b/fake_stripe.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'capybara'
   s.add_dependency 'sinatra'
-  s.add_dependency 'webmock'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'puma'
   s.add_development_dependency 'rspec'

--- a/lib/fake_stripe.rb
+++ b/lib/fake_stripe.rb
@@ -1,5 +1,4 @@
 require 'fake_stripe/configuration'
-require 'fake_stripe/initializers/webmock'
 require 'fake_stripe/stub_app'
 require 'fake_stripe/stub_stripe_js'
 

--- a/lib/fake_stripe/initializers/webmock.rb
+++ b/lib/fake_stripe/initializers/webmock.rb
@@ -1,4 +1,0 @@
-require 'webmock'
-include WebMock::API
-WebMock.enable!
-WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
### Context

The fake_stripe gem should **only** intercept requests from Stripe (on the backend/frontend). https://github.com/thoughtbot/fake_stripe/issues/64

### Changes

- Remove Webmock

### Notes

Feedback is very welcome. Thanks.
