### PR TITLE
Add support for Stripe connect express endpoints

### DIFF
--- a/lib/fake_stripe.rb
+++ b/lib/fake_stripe.rb
@@ -2,6 +2,7 @@ require 'fake_stripe/configuration'
 require 'fake_stripe/initializers/webmock'
 require 'fake_stripe/stub_app'
 require 'fake_stripe/stub_stripe_js'
+require 'fake_stripe/stub_stripe_connect'
 
 module FakeStripe
   extend Configuration
@@ -33,8 +34,10 @@ module FakeStripe
     Stripe.api_key = 'FAKE_STRIPE_API_KEY'
     FakeStripe.reset
     FakeStripe::StubStripeJS.boot_once
+    FakeStripe::StubStripeConnect.boot_once
     stub_request(:any, /api.stripe.com/).to_rack(FakeStripe::StubApp)
   end
 end
 
 STRIPE_JS_HOST = "http://localhost:#{FakeStripe::StubStripeJS.server_port}"
+STRIPE_CONNECT_HOST = "http://localhost:#{FakeStripe::StubStripeConnect.server_port}"

--- a/lib/fake_stripe/bootable.rb
+++ b/lib/fake_stripe/bootable.rb
@@ -1,0 +1,18 @@
+require "capybara"
+require "capybara/server"
+require "fake_stripe/utils"
+
+module Bootable
+  def boot(port = FakeStripe::Utils.find_available_port)
+    instance = new
+    Capybara::Server.new(instance, port: port).tap(&:boot)
+  end
+
+  def boot_once
+    @boot_once ||= boot(server_port)
+  end
+
+  def server_port
+    @server_port ||= FakeStripe::Utils.find_available_port
+  end
+end

--- a/lib/fake_stripe/stub_stripe_connect.rb
+++ b/lib/fake_stripe/stub_stripe_connect.rb
@@ -29,7 +29,7 @@ module FakeStripe
     end
 
     get "/express/oauth/authorize" do
-      uri = URI(params["redirect_uri"])
+      uri = URI(params[:redirect_uri])
       uri.query = URI.encode_www_form(state: params[:state], code: CODE)
       redirect uri
     end

--- a/lib/fake_stripe/stub_stripe_connect.rb
+++ b/lib/fake_stripe/stub_stripe_connect.rb
@@ -1,0 +1,37 @@
+require "fake_stripe/bootable"
+require "sinatra/base"
+
+module FakeStripe
+  class StubStripeConnect < Sinatra::Base
+    extend Bootable
+
+    CODE = "stripe_connect_express_oauth_authorization_code".freeze
+
+    post "/oauth/token" do
+      code = params[:code]
+      if code == CODE
+        {
+          access_token: "ACCESS_TOKEN",
+          livemode: false,
+          refresh_token: "REFRESH_TOEKN",
+          token_type: "bearer",
+          stripe_publishable_key: "PUBLISHABLE_KEY",
+          stripe_user_id: "acc_stripe_user_id",
+          scope: "express",
+        }.to_json
+      else
+        status 400
+        {
+          error: "invalid_grant",
+          error_description: "Authorization code does not exist: #{code}",
+        }.to_json
+      end
+    end
+
+    get "/express/oauth/authorize" do
+      uri = URI(params["redirect_uri"])
+      uri.query = URI.encode_www_form(state: params[:state], code: CODE)
+      redirect uri
+    end
+  end
+end

--- a/lib/fake_stripe/stub_stripe_js.rb
+++ b/lib/fake_stripe/stub_stripe_js.rb
@@ -1,10 +1,10 @@
-require "capybara"
-require "capybara/server"
-require "fake_stripe/utils"
+require "fake_stripe/bootable"
 require "sinatra/base"
 
 module FakeStripe
   class StubStripeJS < Sinatra::Base
+    extend Bootable
+
     get "/v1/" do
       file_path = File.join(File.dirname(__FILE__), "/assets/v1.js")
 
@@ -28,19 +28,6 @@ module FakeStripe
       content_type "text/javascript"
       status 200
       IO.read(file_path)
-    end
-
-    def self.boot(port = FakeStripe::Utils.find_available_port)
-      instance = new
-      Capybara::Server.new(instance, port: port).tap(&:boot)
-    end
-
-    def self.boot_once
-      @@stripe_js_server ||= FakeStripe::StubStripeJS.boot(server_port)
-    end
-
-    def self.server_port
-      @@stripe_js_port ||= FakeStripe::Utils.find_available_port
     end
   end
 end

--- a/spec/fake_stripe/requests/stripe_connect_spec.rb
+++ b/spec/fake_stripe/requests/stripe_connect_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+
+describe "Stripe Connect" do
+  include Rack::Test::Methods
+
+  describe "POST /oauth/token" do
+    context "when the code matches" do
+      it "returns a success response" do
+        post "/oauth/token?code=#{code}"
+
+        expect(last_response.status).to eq(200)
+      end
+
+      it "returns the expected attributes" do
+        post "/oauth/token?code=#{code}"
+
+        response = JSON.parse(last_response.body)
+        expect(response.keys).to contain_exactly(
+          "access_token",
+          "livemode",
+          "refresh_token",
+          "token_type",
+          "stripe_publishable_key",
+          "stripe_user_id",
+          "scope",
+        )
+      end
+    end
+
+    context "when the code does NOT match" do
+      it "returns a 400 response" do
+        post("/oauth/token?code=invalid_code")
+
+        expect(last_response.status).to eq(400)
+      end
+
+      it "returns an error message" do
+        code = "invalid_code"
+        post("/oauth/token?code=#{code}")
+
+        response = JSON.parse(last_response.body)
+        expect(response).to eq(
+          "error" => "invalid_grant",
+          "error_description" => "Authorization code does not exist: #{code}",
+        )
+      end
+    end
+  end
+
+  describe "GET /express/oauth/authorize" do
+    it "redirects to the redirect_uri with the given state and a code" do
+      redirect = "http://example.com/redirect"
+      state = "state"
+      get "/express/oauth/authorize?redirect_uri=#{redirect}&state=#{state}"
+
+      expect(last_response.location).
+        to eq("#{redirect}\?state=#{state}&code=#{code}")
+    end
+  end
+
+  def code
+    FakeStripe::StubStripeConnect::CODE
+  end
+
+  def app
+    FakeStripe::StubStripeConnect.new
+  end
+end

--- a/spec/fake_stripe/stub_stripe_connect_spec.rb
+++ b/spec/fake_stripe/stub_stripe_connect_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
 
-describe FakeStripe::StubStripeJS do
+describe FakeStripe::StubStripeConnect do
   it_behaves_like "a bootable server"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,10 @@ require 'rspec'
 require 'stripe'
 require 'rack/test'
 
+project_root = File.expand_path("..", File.dirname(__FILE__))
+$LOAD_PATH << project_root
+Dir.glob("spec/support/**/*.rb").each { |file| require file }
+
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/shared_examples/bootable.rb
+++ b/spec/support/shared_examples/bootable.rb
@@ -1,0 +1,21 @@
+RSpec.shared_examples "a bootable server" do
+  describe "#boot_once" do
+    it "returns a capybara server" do
+      expect(described_class.boot_once).to be_a(Capybara::Server)
+    end
+
+    it "returns the same server each invocation" do
+      expect(described_class.boot_once).to eq described_class.boot_once
+    end
+  end
+
+  describe "#server_port" do
+    it "returns a port number" do
+      expect(described_class.server_port).to be_an(Integer)
+    end
+
+    it "returns the same value each invocation" do
+      expect(described_class.server_port).to eq described_class.server_port
+    end
+  end
+end


### PR DESCRIPTION
This commit adds support for the Stripe Connect Express Oauth
connection flow as described in
https://stripe.com/docs/connect/express-accounts