### PR TITLE
Use `||=` instead of `or` to suppress warning

### DIFF
--- a/lib/fake_stripe/configuration.rb
+++ b/lib/fake_stripe/configuration.rb
@@ -5,7 +5,7 @@ module FakeStripe
     DEFAULT_FIXTURE_PATH = File.join(File.dirname(__FILE__), 'fixtures/')
 
     def fixture_path
-      @fixture_path or DEFAULT_FIXTURE_PATH
+      @fixture_path ||= DEFAULT_FIXTURE_PATH
     end
 
     def configure


### PR DESCRIPTION
The warning tells us the instance variable is not initialized.