### PR TITLE
Avoid overridding Element native JS class in v3.js

### DIFF
--- a/lib/fake_stripe/assets/v3.js
+++ b/lib/fake_stripe/assets/v3.js
@@ -1,4 +1,4 @@
-class Element {
+class FakeStripeElement {
   mount(el) {
     if (typeof el === "string") {
       el = document.querySelector(el);
@@ -21,7 +21,7 @@ window.Stripe = () => {
   return {
     elements: () => {
       return {
-        create: (type, options) => new Element()
+        create: (type, options) => new FakeStripeElement()
       };
     },
 

--- a/spec/fake_stripe/requests/stripe_js_spec.rb
+++ b/spec/fake_stripe/requests/stripe_js_spec.rb
@@ -31,7 +31,7 @@ describe "Stub Stripe JS" do
 
       response = Net::HTTP.get(url)
 
-      expect(response).to include "class Element"
+      expect(response).to include "class FakeStripeElement"
     end
   end
 end


### PR DESCRIPTION
`Element` is a native JS class and should not be overridden. The current implementation of v3.js might cause issues in other scripts.
https://developer.mozilla.org/en-US/docs/Web/API/Element