### PR TITLE
Support Rails 6 test parallelization

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ RSpec.configure do |config|
 end
 ```
 
+When working on Rails 6.0 or newer and running tests in parallel, you'll need
+to set an environment variable so that Capybara can properly boot a server for
+each worker. To do so, add the following to your `test/test_helper.rb` file:
+
+```ruby
+parallelize_setup do |worker|
+  ENV['TEST_ENV_NUMBER'] = worker.to_s
+end
+```
+
 ## Contributing
 
 Please see [CONTRIBUTING.md][1] for more details.

--- a/lib/fake_stripe/bootable.rb
+++ b/lib/fake_stripe/bootable.rb
@@ -9,10 +9,13 @@ module Bootable
   end
 
   def boot_once
-    @boot_once ||= boot(server_port)
+    @boot_once ||= {}
+    @boot_once[ENV["TEST_ENV_NUMBER"]] ||= boot(server_port)
   end
 
   def server_port
-    @server_port ||= FakeStripe::Utils.find_available_port
+    @server_port ||= {}
+    @server_port[ENV["TEST_ENV_NUMBER"]] ||=
+      FakeStripe::Utils.find_available_port
   end
 end


### PR DESCRIPTION
When using fake_stripe in Rails 6 with tests running in parallel, an "address in use" error is thrown when the Capybara server is booted for all workers that are not the first. This change will start a new server for each worker. 