### PR TITLE
Allow fixtures to be more configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,39 @@ RSpec.configure do |config|
 end
 ```
 
+By default response fixtures can be found in the `lib/fake_stripe/fixtures`
+directory of this gem. If you want to use your own fixtures, you can do:
+```ruby
+FakeStripe.configure do |config|
+  config.fixture_path = "test/fixtures/stripe"
+end
+```
+
+If you want to mix in your own fixtures but fallback to fake_stripes fixtures:
+```ruby
+FakeStripe.configure do |config|
+  config.fixture_paths = [
+    "test/fixtures",
+    FakeStripe::Configuration::DEFAULT_FIXTURE_PATH
+  ]
+end
+```
+
+Finally, if you want to override a fixture to use on a specific endpoint you can
+do the following. This is especially useful if you are fetching something like a
+subscription and testing against different status values.
+
+```ruby
+FakeStripe.configure do |config|
+  # Set up the fixure paths so fake_stripe can find the new fixture
+  config.fixture_paths = [
+    FakeStripe::Configuration::DEFAULT_FIXTURE_PATH
+    "test/fixtures",
+  ]
+  fake_stripe.fixture_override 'retrieve_subscription', 'subscription_retrieve_active'
+end
+```
+
 ## Contributing
 
 Please see [CONTRIBUTING.md][1] for more details.

--- a/lib/fake_stripe/configuration.rb
+++ b/lib/fake_stripe/configuration.rb
@@ -1,11 +1,23 @@
 module FakeStripe
   module Configuration
-    attr_writer :fixture_path
+    attr_writer :fixture_paths
 
     DEFAULT_FIXTURE_PATH = File.join(File.dirname(__FILE__), 'fixtures/')
 
-    def fixture_path
-      @fixture_path or DEFAULT_FIXTURE_PATH
+    def fixture_path=(new_path)
+      @fixture_paths = [new_path]
+    end
+
+    def fixture_paths
+      @fixture_paths || [DEFAULT_FIXTURE_PATH]
+    end
+
+    def fixure_mapping
+      @fixture_mapping ||= Hash.new { |hash, key| hash[key] = key }
+    end
+
+    def fixture_override(old_fixture_key, new_fixture)
+      fixure_mapping[old_fixture_key] = new_fixture
     end
 
     def configure

--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -361,8 +361,12 @@ module FakeStripe
     private
 
     def fixture(file_name)
-      file_path = File.join(FakeStripe.fixture_path, "#{file_name}.json")
-      File.open(file_path, 'rb').read
+      file_name = FakeStripe.fixure_mapping[file_name]
+      fixture_path = FakeStripe.fixture_paths.find do |fixture_path|
+        File.exist? File.join(fixture_path, "#{file_name}.json")
+      end
+
+      File.open(File.join(fixture_path, "#{file_name}.json"), 'rb').read
     end
 
     def json_response(response_code, response_body)

--- a/spec/fake_stripe/configuration_spec.rb
+++ b/spec/fake_stripe/configuration_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe FakeStripe::Configuration, '#fixture_path' do
   let!(:new_fixture_path) { '/custom/fixture/path' }
-  let!(:previous_fixture_path) { FakeStripe.fixture_path }
+  let!(:previous_fixture_paths) { FakeStripe.fixture_paths }
 
   before do
     FakeStripe.configure do |config|
@@ -12,11 +12,11 @@ describe FakeStripe::Configuration, '#fixture_path' do
 
   after do
     FakeStripe.configure do |config|
-      config.fixture_path = previous_fixture_path
+      config.fixture_paths = [previous_fixture_paths]
     end
   end
 
   it 'returns the config fixture path' do
-    expect(FakeStripe.fixture_path).to eq new_fixture_path
+    expect(FakeStripe.fixture_paths).to eq [new_fixture_path]
   end
 end


### PR DESCRIPTION
There is currently no way to swap a fixture for a single endpoint. For
example, testing against different subscription states. This change will
allow the consumer to add multiple fixture directories and override a
specific fixture used in an endpoint without having to override any
other fixtures.