### PR TITLE
Rename Element class

### DIFF
--- a/lib/fake_stripe/assets/v3.js
+++ b/lib/fake_stripe/assets/v3.js
@@ -1,4 +1,4 @@
-class Element {
+class StripeElement {
   mount(el) {
     if (typeof el === "string") {
       el = document.querySelector(el);
@@ -11,6 +11,8 @@ class Element {
       <input placeholder="postal" size="6" type="text">
     `;
   }
+
+  addEventListener() {}
 }
 
 window.Stripe = () => {
@@ -21,7 +23,7 @@ window.Stripe = () => {
   return {
     elements: () => {
       return {
-        create: (type, options) => new Element()
+        create: (type, options) => new StripeElement()
       };
     },
 
@@ -29,6 +31,10 @@ window.Stripe = () => {
       return new Promise(resolve => {
         resolve({ token: { id: "tok_123", card: { last4: fetchLastFour() } } });
       });
+    },
+
+    confirmCardSetup: () => {
+      return Promise.resolve({});
     }
   };
 };


### PR DESCRIPTION
Redefining the [Element class](https://developer.mozilla.org/en-US/docs/Web/API/Element) causes functionality in `rails-ujs` to break. Specifically the logic that handles triggering a `POST` request when a link with `method: :delete` is clicked no longer works as expected. This change renames the class to avoid the conflict.

I'm also adding a few functions that are expected to be defined on the stripe objects:

- `addEventListener` for [input validation](https://stripe.com/docs/js/element/input_validation)
- [`confirmCardSetup`](https://stripe.com/docs/js/setup_intents/confirm_card_setup)