### PR TITLE
Remove enable call from webmocks

### DIFF
--- a/lib/fake_stripe/initializers/webmock.rb
+++ b/lib/fake_stripe/initializers/webmock.rb
@@ -1,3 +1,0 @@
-require 'webmock'
-include WebMock::API
-WebMock.enable!


### PR DESCRIPTION
Just remove the file and let callers set up webmock how they want in their tests.